### PR TITLE
Enable XIP using stage 2 bootloader

### DIFF
--- a/examples/flash_program.zig
+++ b/examples/flash_program.zig
@@ -57,13 +57,13 @@ pub fn main() !void {
 
     // Note that a whole number of sectors (4096 bytes) must be erased at a time
     std.log.info("Erasing target region...", .{});
-    flash.range_erase(flash_target_offset, flash.SECTOR_SIZE);
+    flash.erase(flash_target_offset, flash.SECTOR_SIZE);
     std.log.info("Done. Read back target region:", .{});
     std.log.info("data: {s}", .{flash_target_contents[0..flash.PAGE_SIZE]});
 
     // Note that a whole number of pages (256 bytes) must be written at a time
     std.log.info("Programming target region...", .{});
-    flash.range_program(flash_target_offset, &data);
+    flash.program(flash_target_offset, &data);
     std.log.info("Done. Read back target region:", .{});
     std.log.info("data: {s}", .{flash_target_contents[0..flash.PAGE_SIZE]});
 

--- a/src/hal/flash.zig
+++ b/src/hal/flash.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const rom = @import("rom.zig");
 
 pub const Command = enum(u8) {
@@ -60,7 +62,8 @@ pub const boot2 = struct {
 /// The offset must be aligned to a 4096-byte sector, and count must
 /// be a multiple of 4096 bytes!
 pub fn range_erase(offset: u32, count: u32) linksection(".time_critical") void {
-    // TODO: add sanity checks, e.g., offset + count < flash size
+    std.debug.assert(offset & (SECTOR_SIZE - 1) == 0); // Is correctly aligned?
+    std.debug.assert(count & (SECTOR_SIZE - 1) == 0); // Is a multiple of the sector size?
 
     boot2.flash_init();
 
@@ -80,7 +83,8 @@ pub fn range_erase(offset: u32, count: u32) linksection(".time_critical") void {
 /// The offset must be aligned to a 256-byte boundary, and the length of data
 /// must be a multiple of 256!
 pub fn range_program(offset: u32, data: []const u8) linksection(".time_critical") void {
-    // TODO: add sanity checks, e.g., offset + count < flash size
+    std.debug.assert(offset & (PAGE_SIZE - 1) == 0); // Is correctly aligned?
+    std.debug.assert(data.len & (PAGE_SIZE - 1) == 0); // Is a multiple of the page size?
 
     boot2.flash_init();
 

--- a/src/hal/flash.zig
+++ b/src/hal/flash.zig
@@ -47,14 +47,6 @@ pub const boot2 = struct {
         // instruction. It's important to note that we set the
         // LSB of the address to 1, to prevent the  processor from
         // switching back into arm mode, which would lead to a exception.
-        //asm volatile (
-        //    \\push {lr}
-        //    \\ldr r0, [pc, #4]
-        //    \\adds r0, #1
-        //    \\blx r0
-        //    \\pop {pc}
-        //    \\.4byte hal.flash.boot2.copyout
-        //);
         std.mem.doNotOptimizeAway(asm volatile (
             \\adds r0, #1
             \\blx r0

--- a/src/hal/rom.zig
+++ b/src/hal/rom.zig
@@ -47,9 +47,9 @@ pub const signatures = struct {
     /// Signature of memset4: Sets n bytes start at ptr to the value c and returns ptr; must be word (32-bit) aligned!
     const memset4 = fn (ptr: [*]u32, c: u8, n: u32) [*]u32;
     /// Signature of memcpy: Copies n bytes starting at src to dest and returns dest. The results are undefined if the regions overlap.
-    const memcpy = fn (dest: [*]u8, src: [*]u8, n: u32) [*]u8;
+    const memcpy = fn (dest: [*]u8, src: [*]const u8, n: u32) [*]u8;
     /// Signature of memcpy44: Copies n bytes starting at src to dest and returns dest; must be word (32-bit) aligned!
-    const memcpy44 = fn (dest: [*]u32, src: [*]u32, n: u32) [*]u8;
+    const memcpy44 = fn (dest: [*]u32, src: [*]const u32, n: u32) [*]u8;
     /// Signature of connect_internal_flash: Restore all QSPI pad controls to their default state, and connect the SSI to the QSPI pads
     const connect_internal_flash = fn () void;
     /// Signature of flash_exit_xip: First set up the SSI for serial-mode operations, then issue the fixed XIP exit sequence described in
@@ -189,7 +189,7 @@ pub fn memset(dest: []u8, c: u8) []u8 {
 }
 
 /// Copies n bytes from src to dest; The number of bytes copied is the size of the smaller slice
-pub fn memcpy(dest: []u8, src: []u8) []u8 {
+pub fn memcpy(dest: []u8, src: []const u8) []u8 {
     const S = struct {
         var f: ?*signatures.memcpy = null;
     };


### PR DESCRIPTION
`flash_program` works but linker throws the following warning: 

```
zig build-exe flash_program Debug thumb-freestanding-none: error: warning(link): unexpected LLD stderr:
ld.lld: warning: /home/sugar/Projects/raspberrypi-rp2040/zig-cache/o/028803b950d8e7f25b14783f5f62b5cc/flash_program.o:(function hal.flash.boot2.flash_enable_xip: .time_critical+0x520): branch and link relocation: R_ARM_THM_CALL to non STT_FUNC symbol: hal.flash.boot2.copyout interworking not performed; consider using directive '.type hal.flash.boot2.copyout, %function' to give symbol type STT_FUNC if interworking between ARM and Thumb is required; flash.zig:36 (/home/sugar/Projects/raspberrypi-rp2040/src/hal/flash.zig:36)
```

related to issue #36 