### PR TITLE
examples: Set LED GPIO function

### DIFF
--- a/examples/blinky_core1.zig
+++ b/examples/blinky_core1.zig
@@ -18,6 +18,7 @@ fn core1() void {
 }
 
 pub fn main() !void {
+    led.set_function(.sio);
     led.set_direction(.out);
     multicore.launch_core1(core1);
 

--- a/examples/flash_program.zig
+++ b/examples/flash_program.zig
@@ -28,6 +28,7 @@ pub const std_options = struct {
 };
 
 pub fn main() !void {
+    led.set_function(.sio);
     led.set_direction(.out);
     led.put(1);
 

--- a/examples/random.zig
+++ b/examples/random.zig
@@ -28,6 +28,7 @@ pub const std_options = struct {
 };
 
 pub fn main() !void {
+    led.set_function(.sio);
     led.set_direction(.out);
     led.put(1);
 

--- a/examples/uart.zig
+++ b/examples/uart.zig
@@ -24,6 +24,7 @@ pub const std_options = struct {
 };
 
 pub fn main() !void {
+    led.set_function(.sio);
     led.set_direction(.out);
     led.put(1);
 

--- a/examples/usb_device.zig
+++ b/examples/usb_device.zig
@@ -138,6 +138,7 @@ pub const std_options = struct {
 };
 
 pub fn main() !void {
+    led.set_function(.sio);
     led.set_direction(.out);
     led.put(1);
 

--- a/examples/usb_hid.zig
+++ b/examples/usb_hid.zig
@@ -153,6 +153,7 @@ pub const std_options = struct {
 };
 
 pub fn main() !void {
+    led.set_function(.sio);
     led.set_direction(.out);
     led.put(1);
 


### PR DESCRIPTION
Set the pin function to SIO instead of null (default).

Without this change, the LED won't blink.