### PR TITLE
hal: dma: Cast channel index in claim_unused_channel

### DIFF
--- a/src/hal/dma.zig
+++ b/src/hal/dma.zig
@@ -26,7 +26,7 @@ pub fn claim_unused_channel() ?Channel {
     for (0..num_channels) |i| {
         if (claimed_channels.get(i)) {
             claimed_channels.set(i, true);
-            return channel(i);
+            return channel(@intCast(i));
         }
     }
 


### PR DESCRIPTION
`i` is `usize` but `channel()` expects a `u4`.